### PR TITLE
- UnexpectedNonExhaustive match is generally usable in every scenario…

### DIFF
--- a/src/KeyMatcherFlow.ts
+++ b/src/KeyMatcherFlow.ts
@@ -1,5 +1,5 @@
 import type { AnyRecord } from "./internal/Types";
-import type { KeyMatcher } from "./KeyMatchers";
+import { UnexpectedNonExhaustiveMatchError, type KeyMatcher } from "./KeyMatchers";
 
 export interface KeyMatcherConstrainedFlow<
   Rec extends AnyRecord,
@@ -55,17 +55,18 @@ export const createKeyMatcherConstrainedFlow =
     key: Key
   ): KeyMatcherConstrainedFlow<Rec, KeyMatcher<Rec, never>> =>
   (...funcs: ((...args: any) => any)[]) => {
-    const match = funcs.reduce((previousResult, currentFn) => currentFn(previousResult), {
-      key,
-      record,
-      match: { status: "keyNotInRecord" },
-    } as KeyMatcher<Rec, never>).match;
+    const { match } = funcs.reduce(
+      (previousResult, currentFn) => currentFn(previousResult),
+      {
+        key,
+        record,
+        match: { status: "keyNotInRecord" },
+      } as KeyMatcher<Rec, never>
+    );
     switch (match.status) {
       case "keyInRecord":
         return match.product;
       default:
-        throw new Error(
-          "FATAL: KeyMatchConstrainedFlow is supposed to be exhaustive, yet no match was made previously."
-        );
+        throw new UnexpectedNonExhaustiveMatchError(key as any);
     }
   };

--- a/src/KeyMatcherMappers.ts
+++ b/src/KeyMatcherMappers.ts
@@ -1,6 +1,6 @@
 import type { AnyRecord } from "./internal/Types";
 import { getAnyFromAllegedRecord, primitiveArrayIncludes } from "./internal/Utils";
-import type { KeyMatcher } from "./KeyMatchers";
+import { UnexpectedNonExhaustiveMatchError, type KeyMatcher } from "./KeyMatchers";
 
 /**
  * cases keymatcher mapper
@@ -86,9 +86,7 @@ export const total =
       };
     }
 
-    throw new Error(
-      "FATAL: function total is supposed to be exhaustive on record from previousKeyMatcher, but match did not occour."
-    );
+    throw new UnexpectedNonExhaustiveMatchError(previousKeyMatcher.key);
   };
 
 /**

--- a/src/KeyMatchers.ts
+++ b/src/KeyMatchers.ts
@@ -5,3 +5,13 @@ export interface KeyMatcher<Rec extends AnyRecord, Prod> {
   key: number | string;
   match: { status: "keyInRecord"; product: Prod } | { status: "keyNotInRecord" };
 }
+
+export class UnexpectedNonExhaustiveMatchError extends Error {
+  constructor(public key: string | number) {
+    super(
+      `Match was non-exhaustive! Missing case for ${
+        typeof key === "number" ? key : `"${key}"`
+      }`
+    );
+  }
+}


### PR DESCRIPTION
… where match at runtime wasn't exhaustive

- It is possible for schemas not to include unexpected http responses (e.g.: 5xx responses) in this case it's more helpful if people can deal with an UnexpectedHttpResponseError rather than just an Error